### PR TITLE
Overlap revamp

### DIFF
--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -281,8 +281,8 @@ const days = events
         ...event,
         height,
         top,
-        left: "0",
-        width: "100%",
+        leftPercentage: 0,
+        widthPercentage: 100,
         startRelative: eventDate,
         overlappingDays,
         relative,
@@ -310,39 +310,52 @@ const days = events
   }, [] as CalendarDay[])
   .map((day) => {
     day.events = day.events.map((event) => {
-      const widthPercentage = 100 / (event.overlappingDays.length + 1);
+      const getWidthPercentage = (event) =>
+        100 / (event.overlappingDays.length + 1);
 
-      const eventStartX = event.top;
-      const eventEndX = event.top + event.height;
+      const widthPercentage = getWidthPercentage(event);
 
-      let left = null;
+      let leftPercentage = null;
       for (let overlapDay of event.overlappingDays) {
+        const eventStartX = event.top;
+        const eventEndX = event.top + event.height;
+        const eventStartYPercentage = leftPercentage;
+        const eventEndYPercentage = leftPercentage + widthPercentage;
         const overlapStartX = overlapDay.top;
         const overlapEndX = overlapDay.top + overlapDay.height;
+        const overlapWidthPercentage = getWidthPercentage(overlapDay);
+        const overlapStartYPercentage = overlapDay.leftPercentage;
+        const overlapEndYPercentage =
+          overlapDay.leftPercentage + overlapWidthPercentage;
 
-        // These overlap
+        // These overlap on the X axis
         if (eventStartX >= overlapStartX && eventStartX <= overlapEndX) {
-			debugger;
-          let newLeft = 0;
-          if (left === null) {
-            newLeft = widthPercentage;
-          } else {
-            newLeft = left + widthPercentage;
-          }
+          // These overlap on the Y axis
+          if (
+            eventStartYPercentage >= overlapStartYPercentage &&
+            eventStartYPercentage <= overlapEndYPercentage
+          ) {
+            let newLeft = 0;
+            if (leftPercentage === null) {
+              newLeft = widthPercentage;
+            } else {
+              newLeft = leftPercentage + widthPercentage;
+            }
 
-          if (newLeft >= 100) {
-            left = null;
-          } else {
-            left = newLeft;
+            if (newLeft >= 100) {
+              leftPercentage = null;
+            } else {
+              leftPercentage = newLeft;
+            }
           }
         }
       }
 
-      if (left) {
-        event.left = left;
+      if (leftPercentage) {
+        event.leftPercentage = leftPercentage;
       }
 
-      event.width = `${widthPercentage}%`;
+      event.widthPercentage = widthPercentage;
 
       return event;
     });

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="schedule">
-		<div class="day" v-for="day in days" :key="day.date">
+		<div class="day" v-for="day in days" :key="day.date.format()">
 			<h2>{{ dayjs(day.date).format("MMM. Do") }}</h2>
 
 			<ul>
@@ -14,6 +14,7 @@
 
 <script lang="ts" setup>
 import type { Event } from "./base";
+import calendar from "./calendar";
 import CalendarEvent from "./CalendarEvent.vue";
 
 import dayjs, { Dayjs } from "dayjs";
@@ -24,289 +25,30 @@ dayjs.extend(dayjsFormatPlugin);
 dayjs.extend(dayjsUtcPlugin);
 dayjs.extend(dayjsTimezonePlugin);
 
-// Event times are listed in UTC
-const events: Omit<Event, "height" | "width" | "top" | "relative" | "overlappingDays" | "widthPercentage" | "leftPercentage">[] = [
-{
-	start: '2022 11 04 8:00 PM',
-	end: '2022 11 04 9:00 PM',
-	name: "Minecraft Minigolf",
-	timed: true,
-	backgroundImage: "/assets/mc-minigolf.png",
-	description: `
-	Minecraft Minigolf features an 18-hole minigolf course built on fennifith's survival server. We'll play through the course and track scores - and possibly explore some other minigames in the area!
-	<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 04 9:00 PM',
-	end: '2022 11 04 10:30 PM',
-	name: "Minecraft Advancement Hunt",
-	timed: true,
-	backgroundImage: "/assets/minecraft.jpg",
-	description: `
-	Minecraft Advancement Hunt is a team competition to score the most custom advancements as possible before the other team! The list of advancements will be released shortly before the event.
-	<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 05 6:00 PM',
-	end: '2022 11 05 8:00 PM',
-	name: "Trifox First Playthrough w/ Dev Commentary",
-	timed: true,
-	backgroundImage: "/assets/trifox.jpg",
-	description: `
-	Trifox is a twin-stick action-adventure game inspired by classic platformers that came out on October 14th 2022.
-	<br><a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> is a huge fan of platformers, and will be playing the game for the first time with developer commentary!
-	`.trim()
-},
-{
-	start: '2022 11 05 8:00 PM',
-	end: '2022 11 05 9:30 PM',
-	name: "Minecraft Mega Bedwars",
-	timed: true,
-	backgroundImage: "/assets/mc-bedwars.png",
-	description: `
-	Mega Bedwars is a team bedwars competition set in a custom dimension - based on the outer end island terrain!
-	<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 05 9:30 PM',
-	end: '2022 11 05 10:30 PM',
-	name: "Minecraft Endless Parkour",
-	timed: true,
-	backgroundImage: "/assets/mc-endless-parkour.png",
-	description: `
-	Endless Parkour is an infinite, endless parkour map featuring unique biomes, structures, and redstone features. The objective is to complete as much parkour as possible without falling off, losing health, or getting smacked by a zombie!
-	<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 05 10:00 PM',
-	end: '2022 11 06 1:00 AM',
-	name: "Trifox Speedrunning Attempts",
-	timed: true,
-	backgroundImage: "/assets/trifox.jpg",
-	description: `
-	Trifox is a A twin-stick action-adventure game inspired by classic platformers that came out on October 14th 2022 - it's a new game, but that won't deter <a href="https://twitch.tv/selcouthmind">@selcouthmind on Twitch</a> from speedrunning it.
-	`.trim()
-},
-{
-	start: '2022 11 05 10:30 PM',
-	end: '2022 11 06 12:00 AM',
-	name: "Tetris Effect: Connected",
-	timed: true,
-	backgroundImage: "/assets/tetris_effect.jpg",
-	description: `
-	Tetris Effect: Connected is the latest Tetris game with dazzling graphics, challenging game modes, and more.
-	<br>Join <a href="https://twitch.tv/techygrrrl">@techygrrrl on Twitch</a> to see her incredible capabilities in the game.
-	`.trim()
-},
-{
-	start: '2022 11 04 6:30 PM',
-	end: '2022 11 04 8:00 PM',
-	name: "Minecraft Chaotic Caving",
-	timed: true,
-	backgroundImage: "/assets/mc-chaotic-caving.png",
-	description: `
-	Chaotic Caving is a timed spelunking adventure where teams compete to cave for special ores, find unique boss fights, loot boxes, and custom equipment scattered about the world!
-	<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 06 9:00 PM',
-	end: '2022 11 06 10:30 PM',
-	name: "Minecraft Chaotic Caving #2",
-	timed: true,
-	backgroundImage: "/assets/mc-chaotic-caving.png",
-	description: `
-	Chaotic Caving is a timed spelunking adventure where teams compete to cave for special ores, find unique boss fights, loot boxes, and custom equipment scattered about the world!
-	<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 06 6:00 PM',
-	end: '2022 11 06 9:00 PM',
-	name: "Xonotic DM/CA/CTF",
-	timed: true,
-	backgroundImage: "/assets/xonotic.png",
-	description: `
-	<a href="https://xonotic.org">Xonotic</a> is an arena-style first person shooter that combines interesting and unique features with well-balanced physics and gameplay.
-	We'll be running a few rounds of DM, Clan Arena, and Capture the Flag modes!
-	<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 05 10:00 AM',
-	end: '2022 11 05 11:30 AM',
-	name: "Computer Science Sketchful",
-	timed: true,
-	backgroundImage: "/assets/code.jpg",
-	description: `
-	<a href="https://sketchful.io">Sketchful</a> is a multiplayer pictionary game that we'll be playing with a set of generated Computer Science and Data Structures topics!
-	<br><a href="https://twitch.tv/qarnax_">@Qarnax_ on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 05 11:30 AM',
-	end: '2022 11 05 1:00 PM',
-	name: "CodinGame Escape Rooms",
-	timed: true,
-	backgroundImage: "/assets/code.jpg",
-	description: `
-	<a href="https://escape.codingame.com/">Coding Escape</a> is a set of multiplayer escape room puzzles that combines combines programming, creativity and non-coding exercises.
-	<br><a href="https://twitch.tv/qarnax_">@Qarnax_ on Twitch</a> is hosting this event and it is open to all.
-	`.trim()
-},
-{
-	start: '2022 11 05 3:00 AM',
-	end: '2022 11 05 8:00 AM',
-	name: "Programming with OdatNurd #1",
-	timed: true,
-	backgroundImage: "/assets/code.jpg",
-	description: `
-	<a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
-	`.trim()
-},
-{
-	start: '2022 11 05 8:00 AM',
-	end: '2022 11 05 10:00 AM',
-	name: "Lifeslide Speedrun w/ Dev Commentary",
-	timed: true,
-	backgroundImage: "/assets/lifeslide.jpg",
-	description: `
-	Lifeslide is an atmospheric paper plane flight simulator with arcade gameplay.
-
-	<a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> will be attempting to do speedrun attempts throughout the two-hour block.
-
-	We'll be <a href="https://dreamteck.io">joined by the developers of Lifeslide</a> who will be in VC hanging out and chatting with us!
-	`.trim()
-},
-{
-	start: '2022 11 06 3:00 AM',
-	end: '2022 11 06 7:00 AM',
-	name: "Programming with OdatNurd #2",
-	timed: true,
-	backgroundImage: "/assets/code.jpg",
-	description: `
-	<a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
-	`.trim()
-},
-{
-	start: '2022 11 07 3:00 AM',
-	end: '2022 11 07 7:00 AM',
-	name: "Programming with OdatNurd #3",
-	timed: true,
-	backgroundImage: "/assets/code.jpg",
-	description: `
-	<a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
-	`.trim()
-},
-{
-	start: '2022 11 06 10:00 AM',
-	end: '2022 11 06 4:00 PM',
-	name: "Gaming with CleaverEchsD",
-	timed: true,
-	backgroundImage: "/assets/variety_gaming.png",
-	description: `
-	<a href="https://twitch.tv/cleaverechsd">@cleaverechsd on Twitch</a> will be playing various video games for charity!
-	`.trim()
-},
-{
-	start: '2022 11 06 4:00 PM',
-	end: '2022 11 06 6:00 PM',
-	name: "Gaming with GlitchButSmol",
-	timed: true,
-	backgroundImage: "/assets/variety_gaming.png",
-	description: `
-	<a href="https://twitch.tv/glitchbutsmol">@GlitchButSmol on Twitch</a> will be playing various video games for charity!
-	`.trim()
-},
-{
-	start: '2022 11 06 12:00 AM',
-	end: '2022 11 06 10:00 AM',
-	name: "Dark Souls Cursed Speedrun",
-	timed: true,
-	backgroundImage: "/assets/dark_souls.png",
-	description: `
-	Dark Souls is the notoriously difficult action RPG from FromSoft.
-	<a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> will be attempting to complete the game in one sitting with a friend, while chat is able to make donations in order to add things to the screen or otherwise make the game more challenging. It'll be a blast torturing this poor undead.
-	`.trim()
-}
-].map(({ start, end, ...rest }) => ({
-	// convert start/end times from UTC to local timezone
-	start: dayjs(start).utc(true).local().format("YYYY MM DD h:mm A"),
-	end: dayjs(end).utc(true).local().format("YYYY MM DD h:mm A"),
-	...rest,
-	// Fixes tab ordering
-})).sort((dayA, dayB) => {
-	const dayAStart = dayjs(dayA.start).utc(true);
-	const dayBStart = dayjs(dayB.start).utc(true);
-	return dayAStart.isAfter(dayBStart) ? 1 : -1;
-});
-
-type CalendarDay = {
-	date: string;
-	events: Event[];
-};
-
-const days = events
-.reduce((days, event) => {
+const events = calendar.reduce((events, event) => {
 	const pushEvent = (start: Dayjs, end: Dayjs) => {
 		const eventDate = start.format("YYYY-MM-DD");
 
-		// find/create a day for the event
-		let day = days.find((d) => d.date === eventDate);
-		if (!day) {
-			day = {
-				date: eventDate,
-				events: [],
-			};
-			days.push(day);
-		}
-
-		// look for any previous intersecting events & find their overlappingCount
-		const overlappingDays = day.events.filter((e) => {
-			if (dayjs(e.start).isBefore(start)) {
-				return dayjs(e.end).isAfter(start);
-			} else {
-				return dayjs(e.start).isBefore(end);
-			}
-		});
-
 		const relative = dayjs(eventDate || event.start);
-		const hourStart = Math.max(
-		dayjs(event.start).diff(relative, "minute"),
-		0
+		const minuteStart = Math.max(
+			dayjs(event.start).diff(relative, "minute"),
+			0
 		);
-		const hourEnd = Math.min(
-		dayjs(event.end).diff(relative, "minute"),
-		24 * 60
+		const minuteEnd = Math.min(
+			dayjs(event.end).diff(relative, "minute"),
+			24 * 60
 		);
 
-		const height = (hourEnd - hourStart) / 10;
-		const top = hourStart / 10;
-
-		const finalEvent = {
+		events.push({
 			...event,
-			height,
-			top,
-			leftPercentage: 0,
-			widthPercentage: 100,
-			startRelative: eventDate,
-			overlappingDays,
-			relative,
-			zIndex: 'auto' as const
-		};
+			date: dayjs(eventDate),
 
-		for (let overlappingDay of overlappingDays) {
-			overlappingDay.overlappingDays.push(finalEvent);
-		}
-
-		// push the event into the day list
-		day.events.push(finalEvent);
+			top: minuteStart,
+			height: minuteEnd - minuteStart,
+		})
 	};
 
+	// split events into multiple segments if they span multiple days
 	const eventDateStart = dayjs(event.start).format("YYYY-MM-DD");
 	const eventDateEnd = dayjs(event.end).format("YYYY-MM-DD");
 
@@ -317,60 +59,61 @@ const days = events
 		pushEvent(dayjs(event.start), dayjs(event.end));
 	}
 
+	return events;
+}, [] as Event[]);
+
+function isEventOverlapping(a: Pick<Event, "date" | "top" | "height">, b: Pick<Event, "date" | "top" | "height">) {
+	if (!a.date.isSame(b.date)) return false;
+
+	if (a.top > b.top) {
+		return a.top < (b.top + b.height);
+	} else {
+		return b.top < (a.top + a.height);
+	}
+}
+
+// calculate left/width props for overlapping events
+for (const event of events) {
+	const overlappingEvents = events.filter(e => e != event && isEventOverlapping(event, e));
+
+	event.widthPercentage = 100;
+	event.leftPercentage = 0;
+	for (const e of overlappingEvents) {
+		if (e.leftPercentage && e.leftPercentage < event.leftPercentage + event.widthPercentage) {
+			event.widthPercentage /= 1.5;
+		} else if (e.top <= event.top) {
+			event.leftPercentage = 100 - (100 - event.leftPercentage) / 1.5;
+		}
+	}
+
+	event.widthPercentage = Math.min(
+		event.widthPercentage,
+		100 - event.leftPercentage
+	);
+
+	console.log(event.name, event.widthPercentage, event.leftPercentage);
+}
+
+type CalendarDay = {
+	date: dayjs.Dayjs;
+	events: Event[];
+};
+
+// sort events into day columns
+const days = events.reduce((days, event) => {
+	let day = days.find(d => d.date.isSame(event.date));
+	if (!day) {
+		day = {
+			date: event.date,
+			events: []
+		};
+		days.push(day);
+	}
+
+	day.events.push(event);
+
 	return days;
-}, [] as CalendarDay[])
-.map((day) => {
-	day.events = day.events.map((event) => {
-		const getWidthPercentage = (event) =>
-		event.overlappingDays.length ? (100 / (event.overlappingDays.length + 1)) * 1.5 : 100;
-
-		const widthPercentage = getWidthPercentage(event);
-
-		let leftPercentage = null;
-		for (let overlapDay of event.overlappingDays) {
-			const eventStartX = event.top;
-			const eventEndX = event.top + event.height;
-			const eventStartYPercentage = leftPercentage;
-			const eventEndYPercentage = leftPercentage + widthPercentage;
-			const overlapStartX = overlapDay.top;
-			const overlapEndX = overlapDay.top + overlapDay.height;
-			const overlapWidthPercentage = getWidthPercentage(overlapDay);
-			const overlapStartYPercentage = overlapDay.leftPercentage;
-			const overlapEndYPercentage =
-			overlapDay.leftPercentage + overlapWidthPercentage;
-
-			// These overlap on the X axis
-			if (eventStartX >= overlapStartX && eventStartX <= overlapEndX) {
-				// These overlap on the Y axis
-				if (
-				eventStartYPercentage >= overlapStartYPercentage &&
-				eventStartYPercentage <= overlapEndYPercentage
-				) {
-					let newLeft = 0;
-					if (leftPercentage === null) {
-						newLeft = (overlapWidthPercentage / 1.5);
-					} else {
-						newLeft = leftPercentage + (overlapWidthPercentage / 1.5);
-					}
-
-					const maxLeft = 100 - widthPercentage;
-
-					leftPercentage = Math.min(newLeft, maxLeft);
-				}
-			}
-		}
-
-		if (leftPercentage) {
-			event.leftPercentage = leftPercentage;
-			event.zIndex = leftPercentage;
-		}
-
-		event.widthPercentage = widthPercentage;
-
-		return event;
-	});
-	return day;
-});
+}, [] as CalendarDay[]);
 </script>
 
 <style>
@@ -410,7 +153,7 @@ const days = events
 }
 
 .day {
-	min-width: 14rem;
+	min-width: 15rem;
 }
 
 .day h2 {

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="schedule">
-    <div class="day" v-for="day in days" :key="day.date">
-      <h2>{{ dayjs(day.date).format("MMM. Do") }}</h2>
+	<div class="schedule">
+		<div class="day" v-for="day in days" :key="day.date">
+			<h2>{{ dayjs(day.date).format("MMM. Do") }}</h2>
 
-      <ul>
-        <template v-for="event in day.events" :key="event.name">
-          <CalendarEvent :event="event" />
-        </template>
-      </ul>
-    </div>
-  </div>
+			<ul>
+				<template v-for="event in day.events" :key="event.name">
+					<CalendarEvent :event="event" />
+				</template>
+			</ul>
+		</div>
+	</div>
 </template>
 
 <script lang="ts" setup>
@@ -246,178 +246,178 @@ const events: Omit<Event, "height" | "width" | "top" | "relative" | "overlapping
 });
 
 type CalendarDay = {
-  date: string;
-  events: Event[];
+	date: string;
+	events: Event[];
 };
 
 const days = events
-  .reduce((days, event) => {
-    const pushEvent = (start: Dayjs, end: Dayjs) => {
-      const eventDate = start.format("YYYY-MM-DD");
+.reduce((days, event) => {
+	const pushEvent = (start: Dayjs, end: Dayjs) => {
+		const eventDate = start.format("YYYY-MM-DD");
 
-      // find/create a day for the event
-      let day = days.find((d) => d.date === eventDate);
-      if (!day) {
-        day = {
-          date: eventDate,
-          events: [],
-        };
-        days.push(day);
-      }
+		// find/create a day for the event
+		let day = days.find((d) => d.date === eventDate);
+		if (!day) {
+			day = {
+				date: eventDate,
+				events: [],
+			};
+			days.push(day);
+		}
 
-      // look for any previous intersecting events & find their overlappingCount
-      const overlappingDays = day.events.filter((e) => {
-        if (dayjs(e.start).isBefore(start)) {
-          return dayjs(e.end).isAfter(start);
-        } else {
-          return dayjs(e.start).isBefore(end);
-        }
-      });
+		// look for any previous intersecting events & find their overlappingCount
+		const overlappingDays = day.events.filter((e) => {
+			if (dayjs(e.start).isBefore(start)) {
+				return dayjs(e.end).isAfter(start);
+			} else {
+				return dayjs(e.start).isBefore(end);
+			}
+		});
 
-      const relative = dayjs(eventDate || event.start);
-      const hourStart = Math.max(
-        dayjs(event.start).diff(relative, "minute"),
-        0
-      );
-      const hourEnd = Math.min(
-        dayjs(event.end).diff(relative, "minute"),
-        24 * 60
-      );
+		const relative = dayjs(eventDate || event.start);
+		const hourStart = Math.max(
+		dayjs(event.start).diff(relative, "minute"),
+		0
+		);
+		const hourEnd = Math.min(
+		dayjs(event.end).diff(relative, "minute"),
+		24 * 60
+		);
 
-      const height = (hourEnd - hourStart) / 10;
-      const top = hourStart / 10;
+		const height = (hourEnd - hourStart) / 10;
+		const top = hourStart / 10;
 
-      const finalEvent = {
-        ...event,
-        height,
-        top,
-        leftPercentage: 0,
-        widthPercentage: 100,
-        startRelative: eventDate,
-        overlappingDays,
-        relative,
-		zIndex: 'auto' as const
-      };
+		const finalEvent = {
+			...event,
+			height,
+			top,
+			leftPercentage: 0,
+			widthPercentage: 100,
+			startRelative: eventDate,
+			overlappingDays,
+			relative,
+			zIndex: 'auto' as const
+		};
 
-      for (let overlappingDay of overlappingDays) {
-        overlappingDay.overlappingDays.push(finalEvent);
-      }
+		for (let overlappingDay of overlappingDays) {
+			overlappingDay.overlappingDays.push(finalEvent);
+		}
 
-      // push the event into the day list
-      day.events.push(finalEvent);
-    };
+		// push the event into the day list
+		day.events.push(finalEvent);
+	};
 
-    const eventDateStart = dayjs(event.start).format("YYYY-MM-DD");
-    const eventDateEnd = dayjs(event.end).format("YYYY-MM-DD");
+	const eventDateStart = dayjs(event.start).format("YYYY-MM-DD");
+	const eventDateEnd = dayjs(event.end).format("YYYY-MM-DD");
 
-    if (eventDateStart !== eventDateEnd && dayjs(event.end).hour() > 0) {
-      pushEvent(dayjs(event.start), dayjs(event.start).endOf("day"));
-      pushEvent(dayjs(event.end).startOf("day"), dayjs(event.end));
-    } else {
-      pushEvent(dayjs(event.start), dayjs(event.end));
-    }
+	if (eventDateStart !== eventDateEnd && dayjs(event.end).hour() > 0) {
+		pushEvent(dayjs(event.start), dayjs(event.start).endOf("day"));
+		pushEvent(dayjs(event.end).startOf("day"), dayjs(event.end));
+	} else {
+		pushEvent(dayjs(event.start), dayjs(event.end));
+	}
 
-    return days;
-  }, [] as CalendarDay[])
-  .map((day) => {
-    day.events = day.events.map((event) => {
-      const getWidthPercentage = (event) =>
-	  event.overlappingDays.length ? (100 / (event.overlappingDays.length + 1)) * 1.5 : 100;
+	return days;
+}, [] as CalendarDay[])
+.map((day) => {
+	day.events = day.events.map((event) => {
+		const getWidthPercentage = (event) =>
+		event.overlappingDays.length ? (100 / (event.overlappingDays.length + 1)) * 1.5 : 100;
 
-      const widthPercentage = getWidthPercentage(event);
+		const widthPercentage = getWidthPercentage(event);
 
-      let leftPercentage = null;
-      for (let overlapDay of event.overlappingDays) {
-        const eventStartX = event.top;
-        const eventEndX = event.top + event.height;
-        const eventStartYPercentage = leftPercentage;
-        const eventEndYPercentage = leftPercentage + widthPercentage;
-        const overlapStartX = overlapDay.top;
-        const overlapEndX = overlapDay.top + overlapDay.height;
-        const overlapWidthPercentage = getWidthPercentage(overlapDay);
-        const overlapStartYPercentage = overlapDay.leftPercentage;
-        const overlapEndYPercentage =
-          overlapDay.leftPercentage + overlapWidthPercentage;
+		let leftPercentage = null;
+		for (let overlapDay of event.overlappingDays) {
+			const eventStartX = event.top;
+			const eventEndX = event.top + event.height;
+			const eventStartYPercentage = leftPercentage;
+			const eventEndYPercentage = leftPercentage + widthPercentage;
+			const overlapStartX = overlapDay.top;
+			const overlapEndX = overlapDay.top + overlapDay.height;
+			const overlapWidthPercentage = getWidthPercentage(overlapDay);
+			const overlapStartYPercentage = overlapDay.leftPercentage;
+			const overlapEndYPercentage =
+			overlapDay.leftPercentage + overlapWidthPercentage;
 
-        // These overlap on the X axis
-        if (eventStartX >= overlapStartX && eventStartX <= overlapEndX) {
-          // These overlap on the Y axis
-          if (
-            eventStartYPercentage >= overlapStartYPercentage &&
-            eventStartYPercentage <= overlapEndYPercentage
-          ) {
-            let newLeft = 0;
-            if (leftPercentage === null) {
-              newLeft = (overlapWidthPercentage / 1.5);
-            } else {
-              newLeft = leftPercentage + (overlapWidthPercentage / 1.5);
-            }
+			// These overlap on the X axis
+			if (eventStartX >= overlapStartX && eventStartX <= overlapEndX) {
+				// These overlap on the Y axis
+				if (
+				eventStartYPercentage >= overlapStartYPercentage &&
+				eventStartYPercentage <= overlapEndYPercentage
+				) {
+					let newLeft = 0;
+					if (leftPercentage === null) {
+						newLeft = (overlapWidthPercentage / 1.5);
+					} else {
+						newLeft = leftPercentage + (overlapWidthPercentage / 1.5);
+					}
 
-			const maxLeft = 100 - widthPercentage;
+					const maxLeft = 100 - widthPercentage;
 
-			leftPercentage = Math.min(newLeft, maxLeft);
-          }
-        }
-      }
+					leftPercentage = Math.min(newLeft, maxLeft);
+				}
+			}
+		}
 
-      if (leftPercentage) {
-        event.leftPercentage = leftPercentage;
-		event.zIndex = leftPercentage;
-      }
+		if (leftPercentage) {
+			event.leftPercentage = leftPercentage;
+			event.zIndex = leftPercentage;
+		}
 
-      event.widthPercentage = widthPercentage;
+		event.widthPercentage = widthPercentage;
 
-      return event;
-    });
-    return day;
-  });
+		return event;
+	});
+	return day;
+});
 </script>
 
 <style>
 .schedule {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
-  overflow-x: auto;
-  margin: 2rem 0;
+	display: grid;
+	grid-auto-flow: column;
+	grid-auto-columns: 1fr;
+	overflow-x: auto;
+	margin: 2rem 0;
 }
 
 .schedule ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+	list-style: none;
+	padding: 0;
+	margin: 0;
 
-  height: calc(24 * 6 * 0.5rem);
-  position: relative;
+	height: calc(24 * 6 * 0.5rem);
+	position: relative;
 }
 
 .schedule ul::after {
-  content: " ";
-  display: block;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  opacity: 0.1;
-  z-index: -1;
+	content: " ";
+	display: block;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	opacity: 0.1;
+	z-index: -1;
 
 	background: repeating-linear-gradient(transparent, transparent calc(3rem - 2px), currentColor calc(3rem - 2px), currentColor 3rem);
 }
 
 .schedule li {
-  margin: 0;
+	margin: 0;
 }
 
 .day {
-  min-width: 14rem;
+	min-width: 14rem;
 }
 
 .day h2 {
-  all: unset;
-  display: block;
-  font-size: 1.2rem;
-  text-align: center;
-  border-bottom: 3px solid var(--theme-text-lighter);
+	all: unset;
+	display: block;
+	font-size: 1.2rem;
+	text-align: center;
+	border-bottom: 3px solid var(--theme-text-lighter);
 }
 </style>

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -25,7 +25,7 @@ dayjs.extend(dayjsUtcPlugin);
 dayjs.extend(dayjsTimezonePlugin);
 
 // Event times are listed in UTC
-const events: Omit<Event, "height" | "width" | "top" | "relative" | "left">[] =
+const events: Omit<Event, "height" | "width" | "top" | "relative" | "overlappingDays" | "widthPercentage" | "leftPercentage">[] =
   [
     {
       start: "2022 11 04 8:00 PM",

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -335,7 +335,6 @@ const days = events
             eventStartYPercentage >= overlapStartYPercentage &&
             eventStartYPercentage <= overlapEndYPercentage
           ) {
-			debugger
             let newLeft = 0;
             if (leftPercentage === null) {
               newLeft = overlapWidthPercentage;

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -25,200 +25,201 @@ dayjs.extend(dayjsUtcPlugin);
 dayjs.extend(dayjsTimezonePlugin);
 
 // Event times are listed in UTC
-const events: Omit<Event, 'height' | 'width' | 'top' | 'relative' | 'left'>[] = [
-  {
-    start: "2022 11 04 8:00 PM",
-    end: "2022 11 04 9:00 PM",
-    name: "Minecraft Minigolf",
-    timed: true,
-    backgroundImage: "/assets/mc-minigolf.png",
-    description: `
+const events: Omit<Event, "height" | "width" | "top" | "relative" | "left">[] =
+  [
+    {
+      start: "2022 11 04 8:00 PM",
+      end: "2022 11 04 9:00 PM",
+      name: "Minecraft Minigolf",
+      timed: true,
+      backgroundImage: "/assets/mc-minigolf.png",
+      description: `
 Minecraft Minigolf features an 18-hole minigolf course built on fennifith's survival server. We'll play through the course and track scores - and possibly explore some other minigames in the area!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 04 9:00 PM",
-    end: "2022 11 04 10:30 PM",
-    name: "Minecraft Advancement Hunt",
-    timed: true,
-    backgroundImage: "/assets/minecraft.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 04 9:00 PM",
+      end: "2022 11 04 10:30 PM",
+      name: "Minecraft Advancement Hunt",
+      timed: true,
+      backgroundImage: "/assets/minecraft.jpg",
+      description: `
 Minecraft Advancement Hunt is a team competition to score the most custom advancements as possible before the other team! The list of advancements will be released shortly before the event.
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 05 6:00 PM",
-    end: "2022 11 05 8:00 PM",
-    name: "Trifox First Playthrough w/ Dev Commentary",
-    timed: true,
-    backgroundImage: "/assets/trifox.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 05 6:00 PM",
+      end: "2022 11 05 8:00 PM",
+      name: "Trifox First Playthrough w/ Dev Commentary",
+      timed: true,
+      backgroundImage: "/assets/trifox.jpg",
+      description: `
 Trifox is a twin-stick action-adventure game inspired by classic platformers that came out on October 14th 2022.
 <br><a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> is a huge fan of platformers, and will be playing the game for the first time with developer commentary!
 		`.trim(),
-  },
-  {
-    start: "2022 11 05 8:00 PM",
-    end: "2022 11 05 9:30 PM",
-    name: "Minecraft Mega Bedwars",
-    timed: true,
-    backgroundImage: "/assets/mc-bedwars.png",
-    description: `
+    },
+    {
+      start: "2022 11 05 8:00 PM",
+      end: "2022 11 05 9:30 PM",
+      name: "Minecraft Mega Bedwars",
+      timed: true,
+      backgroundImage: "/assets/mc-bedwars.png",
+      description: `
 Mega Bedwars is a team bedwars competition set in a custom dimension - based on the outer end island terrain!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 05 9:30 PM",
-    end: "2022 11 05 10:30 PM",
-    name: "Minecraft Endless Parkour",
-    timed: true,
-    backgroundImage: "/assets/mc-endless-parkour.png",
-    description: `
+    },
+    {
+      start: "2022 11 05 9:30 PM",
+      end: "2022 11 05 10:30 PM",
+      name: "Minecraft Endless Parkour",
+      timed: true,
+      backgroundImage: "/assets/mc-endless-parkour.png",
+      description: `
 Endless Parkour is an infinite, endless parkour map featuring unique biomes, structures, and redstone features. The objective is to complete as much parkour as possible without falling off, losing health, or getting smacked by a zombie!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 05 10:00 PM",
-    end: "2022 11 06 1:00 AM",
-    name: "Trifox Speedrunning Attempts",
-    timed: true,
-    backgroundImage: "/assets/trifox.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 05 10:00 PM",
+      end: "2022 11 06 1:00 AM",
+      name: "Trifox Speedrunning Attempts",
+      timed: true,
+      backgroundImage: "/assets/trifox.jpg",
+      description: `
 Trifox is a A twin-stick action-adventure game inspired by classic platformers that came out on October 14th 2022 - it's a new game, but that won't deter <a href="https://twitch.tv/selcouthmind">@selcouthmind on Twitch</a> from speedrunning it.
 		`.trim(),
-  },
-  {
-    start: "2022 11 05 10:30 PM",
-    end: "2022 11 06 12:00 AM",
-    name: "Tetris Effect: Connected",
-    timed: true,
-    backgroundImage: "/assets/tetris_effect.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 05 10:30 PM",
+      end: "2022 11 06 12:00 AM",
+      name: "Tetris Effect: Connected",
+      timed: true,
+      backgroundImage: "/assets/tetris_effect.jpg",
+      description: `
 Tetris Effect: Connected is the latest Tetris game with dazzling graphics, challenging game modes, and more.
 <br>Join <a href="https://twitch.tv/techygrrrl">@techygrrrl on Twitch</a> to see her incredible capabilities in the game.
 		`.trim(),
-  },
-  {
-    start: "2022 11 04 6:30 PM",
-    end: "2022 11 04 8:00 PM",
-    name: "Minecraft Chaotic Caving",
-    timed: true,
-    backgroundImage: "/assets/mc-chaotic-caving.png",
-    description: `
+    },
+    {
+      start: "2022 11 04 6:30 PM",
+      end: "2022 11 04 8:00 PM",
+      name: "Minecraft Chaotic Caving",
+      timed: true,
+      backgroundImage: "/assets/mc-chaotic-caving.png",
+      description: `
 Chaotic Caving is a timed spelunking adventure where teams compete to cave for special ores, find unique boss fights, loot boxes, and custom equipment scattered about the world!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 06 9:00 PM",
-    end: "2022 11 06 10:30 PM",
-    name: "Minecraft Chaotic Caving #2",
-    timed: true,
-    backgroundImage: "/assets/mc-chaotic-caving.png",
-    description: `
+    },
+    {
+      start: "2022 11 06 9:00 PM",
+      end: "2022 11 06 10:30 PM",
+      name: "Minecraft Chaotic Caving #2",
+      timed: true,
+      backgroundImage: "/assets/mc-chaotic-caving.png",
+      description: `
 Chaotic Caving is a timed spelunking adventure where teams compete to cave for special ores, find unique boss fights, loot boxes, and custom equipment scattered about the world!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 06 6:00 PM",
-    end: "2022 11 06 9:00 PM",
-    name: "Xonotic DM/CA/CTF",
-    timed: true,
-    backgroundImage: "/assets/xonotic.png",
-    description: `
+    },
+    {
+      start: "2022 11 06 6:00 PM",
+      end: "2022 11 06 9:00 PM",
+      name: "Xonotic DM/CA/CTF",
+      timed: true,
+      backgroundImage: "/assets/xonotic.png",
+      description: `
 <a href="https://xonotic.org">Xonotic</a> is an arena-style first person shooter that combines interesting and unique features with well-balanced physics and gameplay.
 We'll be running a few rounds of DM, Clan Arena, and Capture the Flag modes!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 05 10:00 AM",
-    end: "2022 11 05 11:30 AM",
-    name: "Computer Science Sketchful",
-    timed: true,
-    backgroundImage: "/assets/code.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 05 10:00 AM",
+      end: "2022 11 05 11:30 AM",
+      name: "Computer Science Sketchful",
+      timed: true,
+      backgroundImage: "/assets/code.jpg",
+      description: `
 <a href="https://sketchful.io">Sketchful</a> is a multiplayer pictionary game that we'll be playing with a set of generated Computer Science and Data Structures topics!
 <br><a href="https://twitch.tv/qarnax_">@Qarnax_ on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 05 11:30 AM",
-    end: "2022 11 05 1:00 PM",
-    name: "CodinGame Escape Rooms",
-    timed: true,
-    backgroundImage: "/assets/code.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 05 11:30 AM",
+      end: "2022 11 05 1:00 PM",
+      name: "CodinGame Escape Rooms",
+      timed: true,
+      backgroundImage: "/assets/code.jpg",
+      description: `
 <a href="https://escape.codingame.com/">Coding Escape</a> is a set of multiplayer escape room puzzles that combines combines programming, creativity and non-coding exercises.
 <br><a href="https://twitch.tv/qarnax_">@Qarnax_ on Twitch</a> is hosting this event and it is open to all.
 		`.trim(),
-  },
-  {
-    start: "2022 11 05 3:00 AM",
-    end: "2022 11 05 8:00 AM",
-    name: "Programming with OdatNurd #1",
-    timed: true,
-    backgroundImage: "/assets/code.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 05 3:00 AM",
+      end: "2022 11 05 8:00 AM",
+      name: "Programming with OdatNurd #1",
+      timed: true,
+      backgroundImage: "/assets/code.jpg",
+      description: `
 <a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
         `.trim(),
-  },
-  {
-    start: "2022 11 05 8:00 AM",
-    end: "2022 11 05 10:00 AM",
-    name: "Lifeslide Speedrun w/ Dev Commentary",
-    timed: true,
-    backgroundImage: "/assets/lifeslide.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 05 8:00 AM",
+      end: "2022 11 05 10:00 AM",
+      name: "Lifeslide Speedrun w/ Dev Commentary",
+      timed: true,
+      backgroundImage: "/assets/lifeslide.jpg",
+      description: `
 Lifeslide is an atmospheric paper plane flight simulator with arcade gameplay.
 
 <a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> will be attempting to do speedrun attempts throughout the two-hour block.
 
 We'll be <a href="https://dreamteck.io">joined by the developers of Lifeslide</a> who will be in VC hanging out and chatting with us!
 		`.trim(),
-  },
-  {
-    start: "2022 11 06 3:00 AM",
-    end: "2022 11 06 7:00 AM",
-    name: "Programming with OdatNurd #2",
-    timed: true,
-    backgroundImage: "/assets/code.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 06 3:00 AM",
+      end: "2022 11 06 7:00 AM",
+      name: "Programming with OdatNurd #2",
+      timed: true,
+      backgroundImage: "/assets/code.jpg",
+      description: `
 <a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
         `.trim(),
-  },
-  {
-    start: "2022 11 07 3:00 AM",
-    end: "2022 11 07 7:00 AM",
-    name: "Programming with OdatNurd #3",
-    timed: true,
-    backgroundImage: "/assets/code.jpg",
-    description: `
+    },
+    {
+      start: "2022 11 07 3:00 AM",
+      end: "2022 11 07 7:00 AM",
+      name: "Programming with OdatNurd #3",
+      timed: true,
+      backgroundImage: "/assets/code.jpg",
+      description: `
 <a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
         `.trim(),
-  },
-  {
-    start: "2022 11 06 10:00 AM",
-    end: "2022 11 06 4:00 PM",
-    name: "Gaming with CleaverEchsD",
-    timed: true,
-    backgroundImage: "/assets/variety_gaming.png",
-    description: `
+    },
+    {
+      start: "2022 11 06 10:00 AM",
+      end: "2022 11 06 4:00 PM",
+      name: "Gaming with CleaverEchsD",
+      timed: true,
+      backgroundImage: "/assets/variety_gaming.png",
+      description: `
 <a href="https://twitch.tv/cleaverechsd">@cleaverechsd on Twitch</a> will be playing various video games for charity!
         `.trim(),
-  },
-  {
-    start: "2022 11 06 4:00 PM",
-    end: "2022 11 06 6:00 PM",
-    name: "Gaming with GlitchButSmol",
-    timed: true,
-    backgroundImage: "/assets/variety_gaming.png",
-    description: `
+    },
+    {
+      start: "2022 11 06 4:00 PM",
+      end: "2022 11 06 6:00 PM",
+      name: "Gaming with GlitchButSmol",
+      timed: true,
+      backgroundImage: "/assets/variety_gaming.png",
+      description: `
 <a href="https://twitch.tv/glitchbutsmol">@GlitchButSmol on Twitch</a> will be playing various video games for charity!
         `.trim()
     }
@@ -239,104 +240,114 @@ type CalendarDay = {
   events: Event[];
 };
 
-const days = events.reduce((days, event) => {
-  const pushEvent = (start: Dayjs, end: Dayjs) => {
-    const eventDate = start.format("YYYY-MM-DD");
+const days = events
+  .reduce((days, event) => {
+    const pushEvent = (start: Dayjs, end: Dayjs) => {
+      const eventDate = start.format("YYYY-MM-DD");
 
-    // find/create a day for the event
-    let day = days.find((d) => d.date === eventDate);
-    if (!day) {
-      day = {
-        date: eventDate,
-        events: [],
-      };
-      days.push(day);
-    }
-
-    // look for any previous intersecting events & find their overlappingCount
-    const overlappingDays = day.events.filter((e) => {
-      if (dayjs(e.start).isBefore(start)) {
-        return dayjs(e.end).isAfter(start);
-      } else {
-        return dayjs(e.start).isBefore(end);
+      // find/create a day for the event
+      let day = days.find((d) => d.date === eventDate);
+      if (!day) {
+        day = {
+          date: eventDate,
+          events: [],
+        };
+        days.push(day);
       }
-    });
 
-    const relative = dayjs(eventDate || event.start);
-    const hourStart = Math.max(dayjs(event.start).diff(relative, "minute"), 0);
-    const hourEnd = Math.min(
-      dayjs(event.end).diff(relative, "minute"),
-      24 * 60
-    );
+      // look for any previous intersecting events & find their overlappingCount
+      const overlappingDays = day.events.filter((e) => {
+        if (dayjs(e.start).isBefore(start)) {
+          return dayjs(e.end).isAfter(start);
+        } else {
+          return dayjs(e.start).isBefore(end);
+        }
+      });
 
-	const height = (hourEnd - hourStart) / 10;
-	const top = hourStart / 10;
+      const relative = dayjs(eventDate || event.start);
+      const hourStart = Math.max(
+        dayjs(event.start).diff(relative, "minute"),
+        0
+      );
+      const hourEnd = Math.min(
+        dayjs(event.end).diff(relative, "minute"),
+        24 * 60
+      );
 
-	const finalEvent = {
-      ...event,
-      height,
-      top,
-	  left: '0',
-	  width: '100%',
-      startRelative: eventDate,
-      overlappingDays,
-      relative,
+      const height = (hourEnd - hourStart) / 10;
+      const top = hourStart / 10;
+
+      const finalEvent = {
+        ...event,
+        height,
+        top,
+        left: "0",
+        width: "100%",
+        startRelative: eventDate,
+        overlappingDays,
+        relative,
+      };
+
+      for (let overlappingDay of overlappingDays) {
+        overlappingDay.overlappingDays.push(finalEvent);
+      }
+
+      // push the event into the day list
+      day.events.push(finalEvent);
     };
 
-	for (let overlappingDay of overlappingDays) {
-		overlappingDay.overlappingDays.push(finalEvent);
-	}
+    const eventDateStart = dayjs(event.start).format("YYYY-MM-DD");
+    const eventDateEnd = dayjs(event.end).format("YYYY-MM-DD");
 
-    // push the event into the day list
-    day.events.push(finalEvent);
-  };
+    if (eventDateStart !== eventDateEnd && dayjs(event.end).hour() > 0) {
+      pushEvent(dayjs(event.start), dayjs(event.start).endOf("day"));
+      pushEvent(dayjs(event.end).startOf("day"), dayjs(event.end));
+    } else {
+      pushEvent(dayjs(event.start), dayjs(event.end));
+    }
 
-  const eventDateStart = dayjs(event.start).format("YYYY-MM-DD");
-  const eventDateEnd = dayjs(event.end).format("YYYY-MM-DD");
+    return days;
+  }, [] as CalendarDay[])
+  .map((day) => {
+    day.events = day.events.map((event) => {
+      const widthPercentage = 100 / (event.overlappingDays.length + 1);
 
-  if (eventDateStart !== eventDateEnd && dayjs(event.end).hour() > 0) {
-    pushEvent(dayjs(event.start), dayjs(event.start).endOf("day"));
-    pushEvent(dayjs(event.end).startOf("day"), dayjs(event.end));
-  } else {
-    pushEvent(dayjs(event.start), dayjs(event.end));
-  }
+      const eventStartX = event.top;
+      const eventEndX = event.top + event.height;
 
-  return days;
-}, [] as CalendarDay[])
-.map(day => {
-	day.events = day.events.map(event => {
-	
-		const width = `${100 / (event.overlappingDays.length + 1)}%`;
+      let left = null;
+      for (let overlapDay of event.overlappingDays) {
+        const overlapStartX = overlapDay.top;
+        const overlapEndX = overlapDay.top + overlapDay.height;
 
-		const eventStartX = event.top;
-		const eventEndX = event.top + event.height;
+        // These overlap
+        if (eventStartX >= overlapStartX && eventStartX <= overlapEndX) {
+			debugger;
+          let newLeft = 0;
+          if (left === null) {
+            newLeft = widthPercentage;
+          } else {
+            newLeft = left + widthPercentage;
+          }
 
-		let left = null;
-		for (let overlapDay of event.overlappingDays) {
+          if (newLeft >= 100) {
+            left = null;
+          } else {
+            left = newLeft;
+          }
+        }
+      }
 
-			const overlapStartX = overlapDay.top;
-			const overlapEndX = overlapDay.top + overlapDay.height;
+      if (left) {
+        event.left = left;
+      }
 
-			// These overlap
-			if (eventStartX >= overlapStartX && eventStartX <= overlapEndX) {
-				if (left === null) {
-					left = `calc(${width} * 2)`;
-				} else {
-					left = `calc(${left} + ${width})`
-				}
-			}
-		}
-		
-		if (left) {
-			event.left = left;
-		}
-		
-		event.width = width;
+      event.width = `${widthPercentage}%`;
 
-		return event;
-	})
-	return day;
-});
+      return event;
+    });
+    return day;
+  });
 </script>
 
 <style>

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -262,12 +262,6 @@ const days = events.reduce((days, event) => {
       }
     });
 
-    for (let overlappingDay of overlappingDays) {
-      overlappingDay.overlappingCount += 1;
-    }
-
-    const overlappingCount = overlappingDays.length;
-
     const relative = dayjs(eventDate || event.start);
     const hourStart = Math.max(dayjs(event.start).diff(relative, "minute"), 0);
     const hourEnd = Math.min(
@@ -277,23 +271,24 @@ const days = events.reduce((days, event) => {
 
 	const height = (hourEnd - hourStart) / 10;
 	const top = hourStart / 10;
-	function widthPercentage(this: Event) {
-		return 100 / (this.overlappingCount + 1);
-	}
 
-    // push the event into the day list
-    day.events.push({
+	const finalEvent = {
       ...event,
       height,
       top,
-	  left: `0`,
-      get width() {
-        return `${widthPercentage.call(this)}%`;
-      },
+	  left: '0',
+	  width: '100%',
       startRelative: eventDate,
-      overlappingCount,
+      overlappingDays,
       relative,
-    });
+    };
+
+	for (let overlappingDay of overlappingDays) {
+		overlappingDay.overlappingDays.push(finalEvent);
+	}
+
+    // push the event into the day list
+    day.events.push(finalEvent);
   };
 
   const eventDateStart = dayjs(event.start).format("YYYY-MM-DD");
@@ -307,7 +302,16 @@ const days = events.reduce((days, event) => {
   }
 
   return days;
-}, [] as CalendarDay[]);
+}, [] as CalendarDay[])
+.map(day => {
+	day.events = day.events.map(event => {
+	
+		// event.left = `0`,
+		event.width = `${100 / (event.overlappingDays.length + 1)}%`;
+		return event;
+	})
+	return day;
+});
 </script>
 
 <style>

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -1,20 +1,20 @@
 <template>
-	<div class="schedule">
-		<div class="day" v-for="day in days" :key="day.date">
-			<h2>{{dayjs(day.date).format("MMM. Do")}}</h2>
+  <div class="schedule">
+    <div class="day" v-for="day in days" :key="day.date">
+      <h2>{{ dayjs(day.date).format("MMM. Do") }}</h2>
 
-			<ul>
-				<template v-for="event in day.events" :key="event.name">
-					<CalendarEvent :event="event" />
-				</template>
-			</ul>
-		</div>
-	</div>
+      <ul>
+        <template v-for="event in day.events" :key="event.name">
+          <CalendarEvent :event="event" />
+        </template>
+      </ul>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import type { Event } from './base';
-import CalendarEvent from './CalendarEvent.vue';
+import type { Event } from "./base";
+import CalendarEvent from "./CalendarEvent.vue";
 
 import dayjs, { Dayjs } from "dayjs";
 import dayjsFormatPlugin from "dayjs/plugin/advancedFormat";
@@ -25,200 +25,200 @@ dayjs.extend(dayjsUtcPlugin);
 dayjs.extend(dayjsTimezonePlugin);
 
 // Event times are listed in UTC
-const events: Event[] = [
-	{
-		start: '2022 11 04 8:00 PM',
-		end: '2022 11 04 9:00 PM',
-		name: "Minecraft Minigolf",
-		timed: true,
-		backgroundImage: "/assets/mc-minigolf.png",
-		description: `
+const events: Omit<Event, 'height' | 'width' | 'top' | 'relative' | 'left'>[] = [
+  {
+    start: "2022 11 04 8:00 PM",
+    end: "2022 11 04 9:00 PM",
+    name: "Minecraft Minigolf",
+    timed: true,
+    backgroundImage: "/assets/mc-minigolf.png",
+    description: `
 Minecraft Minigolf features an 18-hole minigolf course built on fennifith's survival server. We'll play through the course and track scores - and possibly explore some other minigames in the area!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-		start: '2022 11 04 9:00 PM',
-		end: '2022 11 04 10:30 PM',
-		name: "Minecraft Advancement Hunt",
-		timed: true,
-		backgroundImage: "/assets/minecraft.jpg",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 04 9:00 PM",
+    end: "2022 11 04 10:30 PM",
+    name: "Minecraft Advancement Hunt",
+    timed: true,
+    backgroundImage: "/assets/minecraft.jpg",
+    description: `
 Minecraft Advancement Hunt is a team competition to score the most custom advancements as possible before the other team! The list of advancements will be released shortly before the event.
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-		start: '2022 11 05 6:00 PM',
-		end: '2022 11 05 8:00 PM',
-		name: "Trifox First Playthrough w/ Dev Commentary",
-		timed: true,
-		backgroundImage: "/assets/trifox.jpg",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 05 6:00 PM",
+    end: "2022 11 05 8:00 PM",
+    name: "Trifox First Playthrough w/ Dev Commentary",
+    timed: true,
+    backgroundImage: "/assets/trifox.jpg",
+    description: `
 Trifox is a twin-stick action-adventure game inspired by classic platformers that came out on October 14th 2022.
 <br><a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> is a huge fan of platformers, and will be playing the game for the first time with developer commentary!
-		`.trim()
-	},
-	{
-		start: '2022 11 05 8:00 PM',
-		end: '2022 11 05 9:30 PM',
-		name: "Minecraft Mega Bedwars",
-		timed: true,
-		backgroundImage: "/assets/mc-bedwars.png",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 05 8:00 PM",
+    end: "2022 11 05 9:30 PM",
+    name: "Minecraft Mega Bedwars",
+    timed: true,
+    backgroundImage: "/assets/mc-bedwars.png",
+    description: `
 Mega Bedwars is a team bedwars competition set in a custom dimension - based on the outer end island terrain!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-		start: '2022 11 05 9:30 PM',
-		end: '2022 11 05 10:30 PM',
-		name: "Minecraft Endless Parkour",
-		timed: true,
-		backgroundImage: "/assets/mc-endless-parkour.png",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 05 9:30 PM",
+    end: "2022 11 05 10:30 PM",
+    name: "Minecraft Endless Parkour",
+    timed: true,
+    backgroundImage: "/assets/mc-endless-parkour.png",
+    description: `
 Endless Parkour is an infinite, endless parkour map featuring unique biomes, structures, and redstone features. The objective is to complete as much parkour as possible without falling off, losing health, or getting smacked by a zombie!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-		start: '2022 11 05 10:00 PM',
-		end: '2022 11 06 1:00 AM',
-		name: "Trifox Speedrunning Attempts",
-		timed: true,
-		backgroundImage: "/assets/trifox.jpg",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 05 10:00 PM",
+    end: "2022 11 06 1:00 AM",
+    name: "Trifox Speedrunning Attempts",
+    timed: true,
+    backgroundImage: "/assets/trifox.jpg",
+    description: `
 Trifox is a A twin-stick action-adventure game inspired by classic platformers that came out on October 14th 2022 - it's a new game, but that won't deter <a href="https://twitch.tv/selcouthmind">@selcouthmind on Twitch</a> from speedrunning it.
-		`.trim()
-	},
-	{
-		start: '2022 11 05 10:30 PM',
-		end: '2022 11 06 12:00 AM',
-		name: "Tetris Effect: Connected",
-		timed: true,
-		backgroundImage: "/assets/tetris_effect.jpg",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 05 10:30 PM",
+    end: "2022 11 06 12:00 AM",
+    name: "Tetris Effect: Connected",
+    timed: true,
+    backgroundImage: "/assets/tetris_effect.jpg",
+    description: `
 Tetris Effect: Connected is the latest Tetris game with dazzling graphics, challenging game modes, and more.
 <br>Join <a href="https://twitch.tv/techygrrrl">@techygrrrl on Twitch</a> to see her incredible capabilities in the game.
-		`.trim()
-	},
-	{
-		start: '2022 11 04 6:30 PM',
-		end: '2022 11 04 8:00 PM',
-		name: "Minecraft Chaotic Caving",
-		timed: true,
-		backgroundImage: "/assets/mc-chaotic-caving.png",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 04 6:30 PM",
+    end: "2022 11 04 8:00 PM",
+    name: "Minecraft Chaotic Caving",
+    timed: true,
+    backgroundImage: "/assets/mc-chaotic-caving.png",
+    description: `
 Chaotic Caving is a timed spelunking adventure where teams compete to cave for special ores, find unique boss fights, loot boxes, and custom equipment scattered about the world!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-		start: '2022 11 06 9:00 PM',
-		end: '2022 11 06 10:30 PM',
-		name: "Minecraft Chaotic Caving #2",
-		timed: true,
-		backgroundImage: "/assets/mc-chaotic-caving.png",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 06 9:00 PM",
+    end: "2022 11 06 10:30 PM",
+    name: "Minecraft Chaotic Caving #2",
+    timed: true,
+    backgroundImage: "/assets/mc-chaotic-caving.png",
+    description: `
 Chaotic Caving is a timed spelunking adventure where teams compete to cave for special ores, find unique boss fights, loot boxes, and custom equipment scattered about the world!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-		start: '2022 11 06 6:00 PM',
-		end: '2022 11 06 9:00 PM',
-		name: "Xonotic DM/CA/CTF",
-		timed: true,
-		backgroundImage: "/assets/xonotic.png",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 06 6:00 PM",
+    end: "2022 11 06 9:00 PM",
+    name: "Xonotic DM/CA/CTF",
+    timed: true,
+    backgroundImage: "/assets/xonotic.png",
+    description: `
 <a href="https://xonotic.org">Xonotic</a> is an arena-style first person shooter that combines interesting and unique features with well-balanced physics and gameplay.
 We'll be running a few rounds of DM, Clan Arena, and Capture the Flag modes!
 <br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-		start: '2022 11 05 10:00 AM',
-		end: '2022 11 05 11:30 AM',
-		name: "Computer Science Sketchful",
-		timed: true,
-		backgroundImage: "/assets/code.jpg",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 05 10:00 AM",
+    end: "2022 11 05 11:30 AM",
+    name: "Computer Science Sketchful",
+    timed: true,
+    backgroundImage: "/assets/code.jpg",
+    description: `
 <a href="https://sketchful.io">Sketchful</a> is a multiplayer pictionary game that we'll be playing with a set of generated Computer Science and Data Structures topics!
 <br><a href="https://twitch.tv/qarnax_">@Qarnax_ on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-		start: '2022 11 05 11:30 AM',
-		end: '2022 11 05 1:00 PM',
-		name: "CodinGame Escape Rooms",
-		timed: true,
-		backgroundImage: "/assets/code.jpg",
-		description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 05 11:30 AM",
+    end: "2022 11 05 1:00 PM",
+    name: "CodinGame Escape Rooms",
+    timed: true,
+    backgroundImage: "/assets/code.jpg",
+    description: `
 <a href="https://escape.codingame.com/">Coding Escape</a> is a set of multiplayer escape room puzzles that combines combines programming, creativity and non-coding exercises.
 <br><a href="https://twitch.tv/qarnax_">@Qarnax_ on Twitch</a> is hosting this event and it is open to all.
-		`.trim()
-	},
-	{
-        start: '2022 11 05 3:00 AM',
-        end: '2022 11 05 8:00 AM',
-        name: "Programming with OdatNurd #1",
-        timed: true,
-        backgroundImage: "/assets/code.jpg",
-        description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 05 3:00 AM",
+    end: "2022 11 05 8:00 AM",
+    name: "Programming with OdatNurd #1",
+    timed: true,
+    backgroundImage: "/assets/code.jpg",
+    description: `
 <a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
-        `.trim()
-    },
-	{
-        start: '2022 11 05 8:00 AM',
-        end: '2022 11 05 10:00 AM',
-        name: "Lifeslide Speedrun w/ Dev Commentary",
-        timed: true,
-        backgroundImage: "/assets/lifeslide.jpg",
-        description: `
+        `.trim(),
+  },
+  {
+    start: "2022 11 05 8:00 AM",
+    end: "2022 11 05 10:00 AM",
+    name: "Lifeslide Speedrun w/ Dev Commentary",
+    timed: true,
+    backgroundImage: "/assets/lifeslide.jpg",
+    description: `
 Lifeslide is an atmospheric paper plane flight simulator with arcade gameplay.
 
 <a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> will be attempting to do speedrun attempts throughout the two-hour block.
 
 We'll be <a href="https://dreamteck.io">joined by the developers of Lifeslide</a> who will be in VC hanging out and chatting with us!
-		`.trim()
-    },
-    {
-        start: '2022 11 06 3:00 AM',
-        end: '2022 11 06 7:00 AM',
-        name: "Programming with OdatNurd #2",
-        timed: true,
-        backgroundImage: "/assets/code.jpg",
-        description: `
+		`.trim(),
+  },
+  {
+    start: "2022 11 06 3:00 AM",
+    end: "2022 11 06 7:00 AM",
+    name: "Programming with OdatNurd #2",
+    timed: true,
+    backgroundImage: "/assets/code.jpg",
+    description: `
 <a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
-        `.trim()
-    },
-    {
-        start: '2022 11 07 3:00 AM',
-        end: '2022 11 07 7:00 AM',
-        name: "Programming with OdatNurd #3",
-        timed: true,
-        backgroundImage: "/assets/code.jpg",
-        description: `
+        `.trim(),
+  },
+  {
+    start: "2022 11 07 3:00 AM",
+    end: "2022 11 07 7:00 AM",
+    name: "Programming with OdatNurd #3",
+    timed: true,
+    backgroundImage: "/assets/code.jpg",
+    description: `
 <a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
-        `.trim()
-    },
-    {
-        start: '2022 11 06 10:00 AM',
-        end: '2022 11 06 4:00 PM',
-        name: "Gaming with CleaverEchsD",
-        timed: true,
-        backgroundImage: "/assets/variety_gaming.png",
-        description: `
+        `.trim(),
+  },
+  {
+    start: "2022 11 06 10:00 AM",
+    end: "2022 11 06 4:00 PM",
+    name: "Gaming with CleaverEchsD",
+    timed: true,
+    backgroundImage: "/assets/variety_gaming.png",
+    description: `
 <a href="https://twitch.tv/cleaverechsd">@cleaverechsd on Twitch</a> will be playing various video games for charity!
-        `.trim()
-    },
-    {
-        start: '2022 11 06 4:00 PM',
-        end: '2022 11 06 6:00 PM',
-        name: "Gaming with GlitchButSmol",
-        timed: true,
-        backgroundImage: "/assets/variety_gaming.png",
-        description: `
+        `.trim(),
+  },
+  {
+    start: "2022 11 06 4:00 PM",
+    end: "2022 11 06 6:00 PM",
+    name: "Gaming with GlitchButSmol",
+    timed: true,
+    backgroundImage: "/assets/variety_gaming.png",
+    description: `
 <a href="https://twitch.tv/glitchbutsmol">@GlitchButSmol on Twitch</a> will be playing various video games for charity!
         `.trim()
     }
@@ -235,103 +235,128 @@ We'll be <a href="https://dreamteck.io">joined by the developers of Lifeslide</a
 });
 
 type CalendarDay = {
-	date: string;
-	events: Event[];
+  date: string;
+  events: Event[];
 };
 
 const days = events.reduce((days, event) => {
-	const pushEvent = (start: Dayjs, end: Dayjs) => {
-		const eventDate = start.format("YYYY-MM-DD");
+  const pushEvent = (start: Dayjs, end: Dayjs) => {
+    const eventDate = start.format("YYYY-MM-DD");
 
-		// find/create a day for the event
-		let day = days.find((d) => d.date === eventDate);
-		if (!day) {
-			day = {
-				date: eventDate,
-				events: [],
-			};
-			days.push(day);
-		}
+    // find/create a day for the event
+    let day = days.find((d) => d.date === eventDate);
+    if (!day) {
+      day = {
+        date: eventDate,
+        events: [],
+      };
+      days.push(day);
+    }
 
-		// look for any previous intersecting events & find their indent
-		const prevIndent = day.events.find(e => {
-			if (dayjs(e.start).isBefore(start)) {
-				return dayjs(e.end).isAfter(start);
-			} else {
-				return dayjs(e.start).isBefore(end);
-			}
-		})?.indent || 0;
-		const indent = prevIndent + 1;
+    // look for any previous intersecting events & find their overlappingCount
+    const overlappingDays = day.events.filter((e) => {
+      if (dayjs(e.start).isBefore(start)) {
+        return dayjs(e.end).isAfter(start);
+      } else {
+        return dayjs(e.start).isBefore(end);
+      }
+    });
 
-		// push the event into the day list
-		day.events.push({
-			...event,
-			startRelative: eventDate,
-			indent,
-		});
-	};
+    for (let overlappingDay of overlappingDays) {
+      overlappingDay.overlappingCount += 1;
+    }
 
-	const eventDateStart = dayjs(event.start).format("YYYY-MM-DD");
-	const eventDateEnd = dayjs(event.end).format("YYYY-MM-DD");
+    const overlappingCount = overlappingDays.length;
 
-	if (eventDateStart !== eventDateEnd && dayjs(event.end).hour() > 0) {
-		pushEvent(dayjs(event.start), dayjs(event.start).endOf('day'));
-		pushEvent(dayjs(event.end).startOf('day'), dayjs(event.end));
-	} else {
-		pushEvent(dayjs(event.start), dayjs(event.end));
+    const relative = dayjs(eventDate || event.start);
+    const hourStart = Math.max(dayjs(event.start).diff(relative, "minute"), 0);
+    const hourEnd = Math.min(
+      dayjs(event.end).diff(relative, "minute"),
+      24 * 60
+    );
+
+	const height = (hourEnd - hourStart) / 10;
+	const top = hourStart / 10;
+	function widthPercentage(this: Event) {
+		return 100 / (this.overlappingCount + 1);
 	}
 
-	return days;
+    // push the event into the day list
+    day.events.push({
+      ...event,
+      height,
+      top,
+	  left: `0`,
+      get width() {
+        return `${widthPercentage.call(this)}%`;
+      },
+      startRelative: eventDate,
+      overlappingCount,
+      relative,
+    });
+  };
+
+  const eventDateStart = dayjs(event.start).format("YYYY-MM-DD");
+  const eventDateEnd = dayjs(event.end).format("YYYY-MM-DD");
+
+  if (eventDateStart !== eventDateEnd && dayjs(event.end).hour() > 0) {
+    pushEvent(dayjs(event.start), dayjs(event.start).endOf("day"));
+    pushEvent(dayjs(event.end).startOf("day"), dayjs(event.end));
+  } else {
+    pushEvent(dayjs(event.start), dayjs(event.end));
+  }
+
+  return days;
 }, [] as CalendarDay[]);
 </script>
 
 <style>
 .schedule {
-	display: grid;
-	grid-auto-flow: column;
-	grid-auto-columns: 1fr;
-	overflow-x: auto;
-	margin: 2rem 0;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  overflow-x: auto;
+  margin: 2rem 0;
 }
 
 .schedule ul {
-	list-style: none;
-	padding: 0;
-	margin: 0;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 
-	height: calc(24 * 6 * .5rem);
-	position: relative;
+  height: calc(24 * 6 * 0.5rem);
+  position: relative;
 }
 
 .schedule ul::after {
-	content: ' ';
-	display: block;
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	opacity: .1;
-	z-index: -1;
+  content: " ";
+  display: block;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  opacity: 0.1;
+  z-index: -1;
 
-	background-image: url("data:image/svg+xml,%3Csvg width='100%25' height='3rem' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cline y1='23' x1='0' y2='23' x2='24' stroke='currentColor' stroke-width='1'/%3E%3C/svg%3E");
-	background-repeat: repeat;
-	background-size: cover contain;
+  background-image: url("data:image/svg+xml,%3Csvg width='100%25' height='3rem' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cline y1='23' x1='0' y2='23' x2='24' stroke='currentColor' stroke-width='1'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: cover contain;
 }
 
 .schedule li {
-	margin: 0;
+  margin: 0;
 }
 
 .day {
-	min-width: 14rem;
+  min-width: 14rem;
 }
 
 .day h2 {
-	all: unset;
-	display: block;
-	font-size: 1.2rem;
-	text-align: center;
-	border-bottom: 3px solid var(--theme-text-lighter);
+  all: unset;
+  display: block;
+  font-size: 1.2rem;
+  text-align: center;
+  border-bottom: 3px solid var(--theme-text-lighter);
 }
 </style>

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -306,8 +306,33 @@ const days = events.reduce((days, event) => {
 .map(day => {
 	day.events = day.events.map(event => {
 	
-		// event.left = `0`,
-		event.width = `${100 / (event.overlappingDays.length + 1)}%`;
+		const width = `${100 / (event.overlappingDays.length + 1)}%`;
+
+		const eventStartX = event.top;
+		const eventEndX = event.top + event.height;
+
+		let left = null;
+		for (let overlapDay of event.overlappingDays) {
+
+			const overlapStartX = overlapDay.top;
+			const overlapEndX = overlapDay.top + overlapDay.height;
+
+			// These overlap
+			if (eventStartX >= overlapStartX && eventStartX <= overlapEndX) {
+				if (left === null) {
+					left = `calc(${width} * 2)`;
+				} else {
+					left = `calc(${left} + ${width})`
+				}
+			}
+		}
+		
+		if (left) {
+			event.left = left;
+		}
+		
+		event.width = width;
+
 		return event;
 	})
 	return day;

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -296,6 +296,7 @@ const days = events
         startRelative: eventDate,
         overlappingDays,
         relative,
+		zIndex: 'auto' as const
       };
 
       for (let overlappingDay of overlappingDays) {
@@ -321,7 +322,7 @@ const days = events
   .map((day) => {
     day.events = day.events.map((event) => {
       const getWidthPercentage = (event) =>
-        100 / (event.overlappingDays.length + 1);
+	  event.overlappingDays.length ? (100 / (event.overlappingDays.length + 1)) * 1.5 : 100;
 
       const widthPercentage = getWidthPercentage(event);
 
@@ -347,22 +348,21 @@ const days = events
           ) {
             let newLeft = 0;
             if (leftPercentage === null) {
-              newLeft = overlapWidthPercentage;
+              newLeft = (overlapWidthPercentage / 1.5);
             } else {
-              newLeft = leftPercentage + overlapWidthPercentage;
+              newLeft = leftPercentage + (overlapWidthPercentage / 1.5);
             }
 
-            if (newLeft >= 100) {
-              leftPercentage = null;
-            } else {
-              leftPercentage = newLeft;
-            }
+			const maxLeft = 100 - widthPercentage;
+
+			leftPercentage = Math.min(newLeft, maxLeft);
           }
         }
       }
 
       if (leftPercentage) {
         event.leftPercentage = leftPercentage;
+		event.zIndex = leftPercentage;
       }
 
       event.widthPercentage = widthPercentage;

--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -335,11 +335,12 @@ const days = events
             eventStartYPercentage >= overlapStartYPercentage &&
             eventStartYPercentage <= overlapEndYPercentage
           ) {
+			debugger
             let newLeft = 0;
             if (leftPercentage === null) {
-              newLeft = widthPercentage;
+              newLeft = overlapWidthPercentage;
             } else {
-              newLeft = leftPercentage + widthPercentage;
+              newLeft = leftPercentage + overlapWidthPercentage;
             }
 
             if (newLeft >= 100) {

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -2,30 +2,30 @@
 	<li
 		class="event-container"
 		:style="{
-			height: `calc(${(props.event.height)} * .5rem)`,
-			top: `calc(${props.event.top} * .5rem)`,
+			height: `${props.event.height / 20}rem`,
+			top: `${props.event.top / 20}rem`,
 			left: `${props.event.leftPercentage}%`,
 			width: `${props.event.widthPercentage}%`,
-			zIndex: props.event.zIndex || `auto`,
+			zIndex: Math.round(props.event.leftPercentage) || `auto`,
 		}"
 	>
-	<button
-		@click="handleOpen"
-		class="event-container-button"
-	>
-		<div class="event">
-			<h3 class="event-name">{{props.event.name}}</h3>
-			<p>
-				{{eventStart}} &mdash; {{eventEnd}}
-			</p>
-		</div>
-	</button>
+		<button
+			@click="handleOpen"
+			class="event-container-button"
+		>
+			<div class="event">
+				<h3 class="event-name">{{props.event.name}}</h3>
+				<p>
+					{{eventStart}} &mdash; {{eventEnd}}
+				</p>
+			</div>
+		</button>
 
-	<CalendarModal
-		:modalOpen="modalOpen"
-		:event="props.event"
-		@close="handleClose"
-	/>
+		<CalendarModal
+			:modalOpen="modalOpen"
+			:event="props.event"
+			@close="handleClose"
+		/>
 	</li>
 </template>
 

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -75,6 +75,10 @@ function handleClose() {
 	padding: 0.2rem 0.3rem;
 }
 
+.event-container:hover, .event-container:focus {
+	z-index: 1000 !important;
+}
+
 .event-container-button {
 	background: unset;
 	border: unset;

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -1,11 +1,12 @@
 <template>
-	<li 
+	<li
 	class="event-container"
 	:style="{
-			height: `calc(${(hourEnd - hourStart) / 10} * .5rem)`,
-			top: `calc(${hourStart/10} * .5rem)`,
-			left: `calc(${props.event.indent} * .5rem)`,
-			right: `calc(-${props.event.indent} * .5rem)`,
+			height: `calc(${(props.event.height)} * .5rem)`,
+			top: `calc(${props.event.top} * .5rem)`,
+			left: props.event.left,
+			width: props.event.width,
+			'--overlappingCount': props.event.overlappingCount
 		}"
 	>
 	<button
@@ -44,10 +45,6 @@ dayjs.extend(dayjsTimezonePlugin);
 const props = defineProps<{
 	event: Event;
 }>();
-
-const relative = dayjs(props.event.startRelative || props.event.start);
-const hourStart = Math.max(dayjs(props.event.start).diff(relative, "minute"), 0);
-const hourEnd = Math.min(dayjs(props.event.end).diff(relative, "minute"), 24*60);
 
 const eventStart = dayjs(props.event.start).format("h:mm A");
 const eventEnd = dayjs(props.event.end).format("h:mm A z");

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -14,7 +14,9 @@
 			class="event-container-button"
 		>
 			<div class="event">
-				<h3 class="event-name">{{props.event.name}}</h3>
+				<h3 :class="`event-name num-lines-${Math.ceil(props.event.height / 60)}`">
+					{{props.event.name}}
+				</h3>
 				<p>
 					{{eventStart}} &mdash; {{eventEnd}}
 				</p>
@@ -76,7 +78,7 @@ function handleClose() {
 }
 
 .event-container:hover, .event-container:focus {
-	z-index: 1000 !important;
+	z-index: 99 !important;
 }
 
 .event-container-button {
@@ -125,6 +127,10 @@ function handleClose() {
 	overflow: hidden;
 	flex-basis: fit-content;
 	flex-shrink: 1;
+}
+
+.event h3.num-lines-1 {
+	white-space: nowrap;
 }
 
 .event p {

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -6,7 +6,7 @@
 			top: `calc(${props.event.top} * .5rem)`,
 			left: `${props.event.leftPercentage}%`,
 			width: `${props.event.widthPercentage}%`,
-			'--overlappingCount': props.event.overlappingDays.length,
+			zIndex: props.event.zIndex || `auto`,
 		}"
 	>
 	<button

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -14,7 +14,7 @@
 		class="event-container-button"
 	>
 		<div class="event">
-			<h3>{{props.event.name}}</h3>
+			<h3 class="event-name">{{props.event.name}}</h3>
 			<p>
 				{{eventStart}} &mdash; {{eventEnd}}
 			</p>
@@ -105,6 +105,8 @@ function handleClose() {
 
 	cursor: pointer;
 	transition: background-color .2s, box-shadow .2s;
+	display: flex;
+	flex-direction: column;
 }
 
 .event h3 {
@@ -114,14 +116,17 @@ function handleClose() {
 	font-size: .8rem;
 	font-weight: 600;
 
-	white-space: nowrap;
+	white-space: break-spaces;
 	text-overflow: ellipsis;
 	overflow: hidden;
+	flex-basis: fit-content;
+	flex-shrink: 1;
 }
 
 .event p {
 	color: var(--theme-text-secondary);
 	font-size: .6rem;
+	flex-shrink: 0;
 }
 
 .event:hover h3 {

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -4,8 +4,8 @@
 	:style="{
 			height: `calc(${(props.event.height)} * .5rem)`,
 			top: `calc(${props.event.top} * .5rem)`,
-			left: props.event.left,
-			width: props.event.width,
+			left: `${props.event.leftPercentage}%`,
+			width: `${props.event.widthPercentage}%`,
 			'--overlappingCount': props.event.overlappingDays.length,
 		}"
 	>

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -6,7 +6,7 @@
 			top: `calc(${props.event.top} * .5rem)`,
 			left: props.event.left,
 			width: props.event.width,
-			'--overlappingCount': props.event.overlappingCount
+			'--overlappingCount': props.event.overlappingDays.length,
 		}"
 	>
 	<button

--- a/src/components/content/base.ts
+++ b/src/components/content/base.ts
@@ -13,6 +13,7 @@ export interface Event {
 	top: number;
 	leftPercentage: number;
 	widthPercentage: number;
+	zIndex?: 'auto' | number;
 	relative: Dayjs;
 };
 

--- a/src/components/content/base.ts
+++ b/src/components/content/base.ts
@@ -4,8 +4,7 @@ export interface Event {
 	startRelative?: string;
 	start: string;
 	end: string;
-	overlappingCount?: number;
-	overlappingIndex?: number;
+	overlappingDays: Event[];
 	name: string;
 	timed: boolean;
 	backgroundImage?: string;

--- a/src/components/content/base.ts
+++ b/src/components/content/base.ts
@@ -1,12 +1,20 @@
+import type { Dayjs } from "dayjs";
+
 export interface Event {
 	startRelative?: string;
 	start: string;
 	end: string;
-	indent?: number;
+	overlappingCount?: number;
+	overlappingIndex?: number;
 	name: string;
 	timed: boolean;
 	backgroundImage?: string;
 	description: string;
+	height: number;
+	top: number;
+	left: string;
+	width: string;
+	relative: Dayjs;
 };
 
 export function slugify(s: string) {

--- a/src/components/content/base.ts
+++ b/src/components/content/base.ts
@@ -1,20 +1,18 @@
 import type { Dayjs } from "dayjs";
 
 export interface Event {
-	startRelative?: string;
-	start: string;
-	end: string;
-	overlappingDays: Event[];
+	date: Dayjs;
+	start: string | Dayjs;
+	end: string | Dayjs;
+
 	name: string;
-	timed: boolean;
 	backgroundImage?: string;
 	description: string;
-	height: number;
-	top: number;
-	leftPercentage: number;
-	widthPercentage: number;
-	zIndex?: 'auto' | number;
-	relative: Dayjs;
+
+	top?: number;
+	height?: number;
+	leftPercentage?: number;
+	widthPercentage?: number;
 };
 
 export function slugify(s: string) {

--- a/src/components/content/base.ts
+++ b/src/components/content/base.ts
@@ -11,8 +11,8 @@ export interface Event {
 	description: string;
 	height: number;
 	top: number;
-	left: string;
-	width: string;
+	leftPercentage: number;
+	widthPercentage: number;
 	relative: Dayjs;
 };
 

--- a/src/components/content/calendar.ts
+++ b/src/components/content/calendar.ts
@@ -1,0 +1,209 @@
+import dayjs from "dayjs";
+import dayjsFormatPlugin from "dayjs/plugin/advancedFormat";
+import dayjsUtcPlugin from "dayjs/plugin/utc";
+import dayjsTimezonePlugin from "dayjs/plugin/timezone";
+dayjs.extend(dayjsFormatPlugin);
+dayjs.extend(dayjsUtcPlugin);
+dayjs.extend(dayjsTimezonePlugin);
+
+// Event times are listed in UTC
+export default [
+	{
+		start: '2022 11 04 8:00 PM',
+		end: '2022 11 04 9:00 PM',
+		name: "Minecraft Minigolf",
+		backgroundImage: "/assets/mc-minigolf.png",
+		description: `
+		Minecraft Minigolf features an 18-hole minigolf course built on fennifith's survival server. We'll play through the course and track scores - and possibly explore some other minigames in the area!
+		<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 04 9:00 PM',
+		end: '2022 11 04 10:30 PM',
+		name: "Minecraft Advancement Hunt",
+		backgroundImage: "/assets/minecraft.jpg",
+		description: `
+		Minecraft Advancement Hunt is a team competition to score the most custom advancements as possible before the other team! The list of advancements will be released shortly before the event.
+		<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 05 6:00 PM',
+		end: '2022 11 05 8:00 PM',
+		name: "Trifox First Playthrough w/ Dev Commentary",
+		backgroundImage: "/assets/trifox.jpg",
+		description: `
+		Trifox is a twin-stick action-adventure game inspired by classic platformers that came out on October 14th 2022.
+		<br><a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> is a huge fan of platformers, and will be playing the game for the first time with developer commentary!
+		`.trim()
+	},
+	{
+		start: '2022 11 05 8:00 PM',
+		end: '2022 11 05 9:30 PM',
+		name: "Minecraft Mega Bedwars",
+		backgroundImage: "/assets/mc-bedwars.png",
+		description: `
+		Mega Bedwars is a team bedwars competition set in a custom dimension - based on the outer end island terrain!
+		<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 05 9:30 PM',
+		end: '2022 11 05 10:30 PM',
+		name: "Minecraft Endless Parkour",
+		backgroundImage: "/assets/mc-endless-parkour.png",
+		description: `
+		Endless Parkour is an infinite, endless parkour map featuring unique biomes, structures, and redstone features. The objective is to complete as much parkour as possible without falling off, losing health, or getting smacked by a zombie!
+		<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 05 10:00 PM',
+		end: '2022 11 06 1:00 AM',
+		name: "Trifox Speedrunning Attempts",
+		backgroundImage: "/assets/trifox.jpg",
+		description: `
+		Trifox is a A twin-stick action-adventure game inspired by classic platformers that came out on October 14th 2022 - it's a new game, but that won't deter <a href="https://twitch.tv/selcouthmind">@selcouthmind on Twitch</a> from speedrunning it.
+		`.trim()
+	},
+	{
+		start: '2022 11 05 10:30 PM',
+		end: '2022 11 06 12:00 AM',
+		name: "Tetris Effect: Connected",
+		backgroundImage: "/assets/tetris_effect.jpg",
+		description: `
+		Tetris Effect: Connected is the latest Tetris game with dazzling graphics, challenging game modes, and more.
+		<br>Join <a href="https://twitch.tv/techygrrrl">@techygrrrl on Twitch</a> to see her incredible capabilities in the game.
+		`.trim()
+	},
+	{
+		start: '2022 11 04 6:30 PM',
+		end: '2022 11 04 8:00 PM',
+		name: "Minecraft Chaotic Caving",
+		backgroundImage: "/assets/mc-chaotic-caving.png",
+		description: `
+		Chaotic Caving is a timed spelunking adventure where teams compete to cave for special ores, find unique boss fights, loot boxes, and custom equipment scattered about the world!
+		<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 06 9:00 PM',
+		end: '2022 11 06 10:30 PM',
+		name: "Minecraft Chaotic Caving #2",
+		backgroundImage: "/assets/mc-chaotic-caving.png",
+		description: `
+		Chaotic Caving is a timed spelunking adventure where teams compete to cave for special ores, find unique boss fights, loot boxes, and custom equipment scattered about the world!
+		<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 06 6:00 PM',
+		end: '2022 11 06 9:00 PM',
+		name: "Xonotic DM/CA/CTF",
+		backgroundImage: "/assets/xonotic.png",
+		description: `
+		<a href="https://xonotic.org">Xonotic</a> is an arena-style first person shooter that combines interesting and unique features with well-balanced physics and gameplay.
+		We'll be running a few rounds of DM, Clan Arena, and Capture the Flag modes!
+		<br><a href="https://twitch.tv/fennifith">@fennifith on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 05 10:00 AM',
+		end: '2022 11 05 11:30 AM',
+		name: "Computer Science Sketchful",
+		backgroundImage: "/assets/code.jpg",
+		description: `
+		<a href="https://sketchful.io">Sketchful</a> is a multiplayer pictionary game that we'll be playing with a set of generated Computer Science and Data Structures topics!
+		<br><a href="https://twitch.tv/qarnax_">@Qarnax_ on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 05 11:30 AM',
+		end: '2022 11 05 1:00 PM',
+		name: "CodinGame Escape Rooms",
+		backgroundImage: "/assets/code.jpg",
+		description: `
+		<a href="https://escape.codingame.com/">Coding Escape</a> is a set of multiplayer escape room puzzles that combines combines programming, creativity and non-coding exercises.
+		<br><a href="https://twitch.tv/qarnax_">@Qarnax_ on Twitch</a> is hosting this event and it is open to all.
+		`.trim()
+	},
+	{
+		start: '2022 11 05 3:00 AM',
+		end: '2022 11 05 8:00 AM',
+		name: "Programming with OdatNurd #1",
+		backgroundImage: "/assets/code.jpg",
+		description: `
+		<a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
+		`.trim()
+	},
+	{
+		start: '2022 11 05 8:00 AM',
+		end: '2022 11 05 10:00 AM',
+		name: "Lifeslide Speedrun w/ Dev Commentary",
+		backgroundImage: "/assets/lifeslide.jpg",
+		description: `
+		Lifeslide is an atmospheric paper plane flight simulator with arcade gameplay.
+
+		<a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> will be attempting to do speedrun attempts throughout the two-hour block.
+
+		We'll be <a href="https://dreamteck.io">joined by the developers of Lifeslide</a> who will be in VC hanging out and chatting with us!
+		`.trim()
+	},
+	{
+		start: '2022 11 06 3:00 AM',
+		end: '2022 11 06 7:00 AM',
+		name: "Programming with OdatNurd #2",
+		backgroundImage: "/assets/code.jpg",
+		description: `
+		<a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
+		`.trim()
+	},
+	{
+		start: '2022 11 07 3:00 AM',
+		end: '2022 11 07 7:00 AM',
+		name: "Programming with OdatNurd #3",
+		backgroundImage: "/assets/code.jpg",
+		description: `
+		<a href="https://twitch.tv/OdatNurd">@OdatNurd on Twitch</a> is an amazing developer with a super friendly community. You won't want to miss the insights he provides while he develops neat stuff on stream!
+		`.trim()
+	},
+	{
+		start: '2022 11 06 10:00 AM',
+		end: '2022 11 06 4:00 PM',
+		name: "Gaming with CleaverEchsD",
+		backgroundImage: "/assets/variety_gaming.png",
+		description: `
+		<a href="https://twitch.tv/cleaverechsd">@cleaverechsd on Twitch</a> will be playing various video games for charity!
+		`.trim()
+	},
+	{
+		start: '2022 11 06 4:00 PM',
+		end: '2022 11 06 6:00 PM',
+		name: "Gaming with GlitchButSmol",
+		backgroundImage: "/assets/variety_gaming.png",
+		description: `
+		<a href="https://twitch.tv/glitchbutsmol">@GlitchButSmol on Twitch</a> will be playing various video games for charity!
+		`.trim()
+	},
+	{
+		start: '2022 11 06 12:00 AM',
+		end: '2022 11 06 10:00 AM',
+		name: "Dark Souls Cursed Speedrun",
+		backgroundImage: "/assets/dark_souls.png",
+		description: `
+		Dark Souls is the notoriously difficult action RPG from FromSoft.
+		<a href="https://twitch.tv/crutchcorn">@crutchcorn on Twitch</a> will be attempting to complete the game in one sitting with a friend, while chat is able to make donations in order to add things to the screen or otherwise make the game more challenging. It'll be a blast torturing this poor undead.
+		`.trim()
+	}
+].map(({ start, end, ...rest }) => ({
+	// convert start/end times from UTC to local timezone
+	start: dayjs(start).utc(true).local().format("YYYY MM DD h:mm A"),
+	end: dayjs(end).utc(true).local().format("YYYY MM DD h:mm A"),
+	...rest,
+	// Fixes tab ordering
+})).sort((dayA, dayB) => {
+	const dayAStart = dayjs(dayA.start).utc(true);
+	const dayBStart = dayjs(dayB.start).utc(true);
+	return dayAStart.isAfter(dayBStart) ? 1 : -1;
+});


### PR DESCRIPTION
> This PR builds on top of #2, merge that in first

This PR revamps the method by which we handle overlapped events. Previously, we simply added an indent to the left of an event. While this worked, it had a few issues:

1) It led to potentially overflowing to the right-hand side of the calendar event, meaning that it could overlap with events from a different day
2) In some circumstances, events were overflowing and hiding text from other events because of how it was structured.

These issues were made more pronounced when I attempted to add in #3 to our schedule.

Below are screenshots from that event:

# Previous Screenshot

![image](https://user-images.githubusercontent.com/9100169/197382081-3f64ed05-0396-4a0e-87f1-25eb083601ba.png)

# New Screenshot

![image](https://user-images.githubusercontent.com/9100169/197382108-66154c37-6b6e-47a1-912e-c8d49e42f86a.png)
