### PR TITLE
Fix calendar background

### DIFF
--- a/src/components/content/Calendar.vue
+++ b/src/components/content/Calendar.vue
@@ -325,9 +325,7 @@ const days = events.reduce((days, event) => {
 	opacity: .1;
 	z-index: -1;
 
-	background-image: url("data:image/svg+xml,%3Csvg width='100%25' height='3rem' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cline y1='23' x1='0' y2='23' x2='24' stroke='currentColor' stroke-width='1'/%3E%3C/svg%3E");
-	background-repeat: repeat;
-	background-size: cover contain;
+	background: repeating-linear-gradient(transparent, transparent calc(3rem - 2px), currentColor calc(3rem - 2px), currentColor 3rem);
 }
 
 .schedule li {

--- a/src/components/content/CalendarEvent.vue
+++ b/src/components/content/CalendarEvent.vue
@@ -99,7 +99,7 @@ function handleClose() {
 	width: 100%;
 	height: 100%;
 	min-height: 2rem;
-	padding: .2rem .6rem;
+	padding: .4rem .6rem;
 
 	border: 1px solid var(--theme-text-accent);
 	box-shadow: 0 3px .6rem hsla(var(--color-accent), 0.3);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -87,8 +87,12 @@
 
 body {
 	background: var(--theme-bg);
-	background: linear-gradient(180deg, var(--theme-bg), hsla(var(--color-accent), 0.1));
+	background: linear-gradient(180deg, var(--theme-bg), hsl(var(--color-base-accent), 92%));
 	color: var(--theme-text);
+}
+
+:root.theme-dark body {
+	background: linear-gradient(180deg, var(--theme-bg), hsl(var(--color-base-accent), 5%));
 }
 
 :root.theme-dark {


### PR DESCRIPTION
Rewrites the calendar background to use `repeating-linear-gradient`, which calculates the size correctly on firefox.

Also fixes the background gradient being improperly themed on some browsers.