### PR TITLE
Fix calendar modal bugs

### DIFF
--- a/src/components/content/CalendarModal.vue
+++ b/src/components/content/CalendarModal.vue
@@ -86,13 +86,15 @@ const eventStart = dayjs(props.event.start).format("h:mm A");
 const eventEnd = dayjs(props.event.end).format("h:mm A (zzz)");
 
 function handleSave() {
-	const start = dayjs(props.event.start);
-	const end = dayjs(props.event.end);
+	const start = dayjs(props.event.start).utc();
+	const end = dayjs(props.event.end).utc();
 	const cal = createEvent({
 		title: props.event.name,
 		description: props.event.description,
-		start: [start.year(), start.month(), start.date(), start.hour(), start.minute()],
-		end: [end.year(), end.month(), end.date(), end.hour(), end.minute()],
+		start: [start.year(), start.month() + 1, start.date(), start.hour(), start.minute()],
+		startInputType: 'utc',
+		end: [end.year(), end.month() + 1, end.date(), end.hour(), end.minute()],
+		endInputType: 'utc',
 	});
 
 	if (cal.value) {

--- a/src/components/content/CalendarModal.vue
+++ b/src/components/content/CalendarModal.vue
@@ -3,7 +3,13 @@
 		<div class="modal-container" @click="(e) => e.target === e.currentTarget && $emit('close')">
 			<div class="modal">
 				<div class="modal-title">
-					<img v-if="props.event.backgroundImage" :src="props.event.backgroundImage" />
+					<div
+						v-if="props.event.backgroundImage"
+						class="modal-image"
+						:style="{
+							backgroundImage: `url('${props.event.backgroundImage}')`
+						}"
+					/>
 
 					<h1>
 						<span>{{props.event.name}}</span><br/>
@@ -133,11 +139,13 @@ function handleSave() {
 	min-height: 5.5rem;
 }
 
-.modal-title img {
+.modal-title .modal-image {
 	width: 100%;
 	vertical-align: bottom;
 	aspect-ratio: 16 / 9;
 	background-color: #000;
+	background-size: cover;
+	background-position: center;
 }
 
 .modal-title h1 {
@@ -159,7 +167,7 @@ function handleSave() {
 	font-weight: 600;
 }
 
-.modal-title img + h1 {
+.modal-title .modal-image + h1 {
 	color: #FFF;
 	background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.6) 50%, rgba(0, 0, 0, .8));
 }


### PR DESCRIPTION
- Uses the correct month/time zone values for ICS export
- Sets `background-size: cover;` on the modal header to avoid squashed images